### PR TITLE
🌐 Update translations - 6 files

### DIFF
--- a/input/bg.json
+++ b/input/bg.json
@@ -1,18 +1,18 @@
 {
   "common": {
-    "new_string": "Neue Zeichenkette"
+    "new_string": "Нова низ"
   },
   "translations": {
-    "where_did_you_see_him": "Wo hast du ihn gesehen?",
-    "i_cant_make_up_my_mind": "Ich kann mich nicht entscheiden test.asd asd",
-    "i_want_to_go_to_France": "Ich möchte nach Frankreich gehen.",
-    "thats_it_go_to_timeout": "Das reicht, ab in die Auszeit!",
-    "he_reminds_me_of_your_brother": "Er erinnert mich an deinen Bruder.",
+    "where_did_you_see_him": "Къде го видя?",
+    "i_cant_make_up_my_mind": "Не мога да взема решение test.asd asd",
+    "i_want_to_go_to_France": "Искам да отида във Франция.",
+    "thats_it_go_to_timeout": "Достатъчно, време е за почивка!",
+    "he_reminds_me_of_your_brother": "Той ми напомня на твоя брат.",
     "his_father_owns_the_restaurant": "Sein Vater besitzt das Restaurant.",
-    "it_was_all_just_a_big_misunderstanding": "Es war alles nur ein großes Missverständnis.",
-    "he_adds_something_different_to_the_team": "Er bringt etwas anderes ins Team ein.",
-    "i_told_him_id_spank_the_suitcase_for_being_bad": "Ich sagte ihm, ich würde den Koffer dafür bestrafen, dass er unartig war.",
-    "you_use_this_after_something_broken_has_been_repaired": "Du benutzt das, nachdem etwas Kaputtes repariert wurde.",
-    "you_use_this_after_something_broken_has_been": "Du benutzt das, nachdem etwas Kaputtes repariert"
+    "it_was_all_just_a_big_misunderstanding": "Всичко беше просто едно голямо недоразумение.",
+    "he_adds_something_different_to_the_team": "Той внася нещо различно в екипа.",
+    "i_told_him_id_spank_the_suitcase_for_being_bad": "Казах му, че ще накажа куфара, защото беше непослушен.",
+    "you_use_this_after_something_broken_has_been_repaired": "Използваш това, след като нещо счупено е било поправено.",
+    "you_use_this_after_something_broken_has_been": "Използваш това, след като нещо счупено е поправено"
   }
 }

--- a/input/cs.json
+++ b/input/cs.json
@@ -1,0 +1,18 @@
+{
+  "common": {
+    "new_string": "Nový řetězec"
+  },
+  "translations": {
+    "where_did_you_see_him": "Kde jsi ho viděl?",
+    "i_cant_make_up_my_mind": "Nemohu se rozhodnout test.asd asd",
+    "i_want_to_go_to_France": "Chci jet do Francie.",
+    "thats_it_go_to_timeout": "To stačí, jdi na časový limit!",
+    "he_reminds_me_of_your_brother": "Připomíná mi tvého bratra.",
+    "his_father_owns_the_restaurant": "Jeho otec vlastní tu restauraci.",
+    "it_was_all_just_a_big_misunderstanding": "Bylo to všechno jen velké nedorozumění.",
+    "he_adds_something_different_to_the_team": "Přináší do týmu něco jiného.",
+    "i_told_him_id_spank_the_suitcase_for_being_bad": "Řekl jsem mu, že ten kufr potrestám za to, že byl nezbedný.",
+    "you_use_this_after_something_broken_has_been_repaired": "Použiješ to poté, co bylo něco rozbitého opraveno.",
+    "you_use_this_after_something_broken_has_been": "Používáš to poté, co bylo něco rozbitého opraveno"
+  }
+}


### PR DESCRIPTION
## Translation Update

This PR contains updated translation files from the transl8 platform.

### Summary
- **Files created**: 1
- **Files updated**: 5
- **Languages**: 6


### Files changed
- `input/en.json`
- `input/de.json`
- `input/fr.json`
- `input/es.json`
- `input/it.json`
- `input/cs.json`

### Languages
- **English** (en): 12 translations
- **German** (de): 12 translations
- **french** (fr): 12 translations
- **Spanish** (es): 12 translations
- **Italian** (it): 12 translations
- **Czech** (cs): 12 translations



---
*Generated by transl8 platform*